### PR TITLE
Fix Chart and Historical endpoint

### DIFF
--- a/index.html
+++ b/index.html
@@ -400,7 +400,9 @@
 				<div class="card-options "></div>
 			</div>
 			<div>
-				<div id="linechart_material" class="chart" dir="ltr"></div>
+				<div id="linechart_material" class="chart" dir="ltr">
+					<div class="waitChart"><span class="loader__dot">.</span><span class="loader__dot">.</span><span class="loader__dot">.</span>جاري تحميل المبيان</div>					
+				</div>
 			</div>
 		</div>
 	</div>

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -282,7 +282,25 @@ font-size: 50px;
 }
 .navbar-nav{
 	margin-left: 250px;
+}
 
+.waitChart{
+	text-align: center;
+	font-weight: bold;
+	padding: 10%;
+}
+
+@keyframes blink {
+	50% { color: transparent }
+}
+.loader__dot { 
+	animation: 1s blink infinite 
+}
+.loader__dot:nth-child(2) { 
+	animation-delay: 250ms 
+}
+.loader__dot:nth-child(3) {
+	 animation-delay: 500ms 
 }
 
 .wtm {

--- a/src/js/historical.js
+++ b/src/js/historical.js
@@ -1,13 +1,14 @@
-const api_url_hestori = 'https://corona.lmao.ninja/historical';
+const api_url_hestori = 'https://corona.lmao.ninja/v2/historical/morocco?lastdays=all';
 	
 async function getHestorical() {
     var valChart = new Array(),
         i=0;
-    const   response = await fetch(api_url_hestori),
+        
+    const response = await fetch(api_url_hestori),
             data = await response.json(),
-            cases = data[63].timeline['cases'],
-            deaths = data[63].timeline['deaths'],
-            recovered = data[63].timeline['recovered'],
+            cases = data.timeline['cases'],
+            deaths = data.timeline['deaths'],
+            recovered = data.timeline['recovered'],
             count = Object.keys(cases).length;
 
     $.each( cases, function( key, value ) {
@@ -17,10 +18,7 @@ async function getHestorical() {
             $('.statistique').append(col);
             i++;
         }
-
     });
-    //console.log(valChart);
-    //chart script
 
     google.charts.load('current', {'packages':['line']});
     google.charts.setOnLoadCallback(drawChart);
@@ -32,11 +30,8 @@ async function getHestorical() {
     chartdata.addColumn('number', 'الحالات');
     chartdata.addColumn('number', 'الوفيات');
     chartdata.addColumn('number', 'المتعافون');
-
-      console.log(valChart);
-      chartdata.addRows(valChart);
-  
-    
+      
+    chartdata.addRows(valChart);
 
     var options = {
       width: '100%',
@@ -45,9 +40,23 @@ async function getHestorical() {
 
     var chart = new google.charts.Line(document.getElementById('linechart_material'));
 
-    chart.draw(chartdata, google.charts.Line.convertOptions(options));
+    const draw = () => {
+      chart.draw(chartdata, google.charts.Line.convertOptions(options));
+    }
+
+    draw()
+    
+    if (window.addEventListener) {
+      window.addEventListener('resize', draw);
+    }
+    else if (window.attachEvent) { // for old browser version
+      window.attachEvent('onresize', draw);
+    }
+    else {
+      window.resize = draw;
+    }  
   }
 
-
 }
+
 getHestorical();


### PR DESCRIPTION
**Linked issue** [#21](https://github.com/moroccanprogrammers/moroccovid-19/issues/21)

+ Change historical data to the [new one](https://corona.lmao.ninja/v2/historical) and save some bandwidth by selecting **Morocco** in the HTTP query.
+ ...So the chart is fixed as well.
+ Make Chart resizable and display a loading text while getting data from historical.
